### PR TITLE
feat(): Implement role based project creation

### DIFF
--- a/backend/gateways/user_gateway.go
+++ b/backend/gateways/user_gateway.go
@@ -36,22 +36,30 @@ func UserGatewayInit() *UserGateway {
 	}
 }
 
-func (g *UserGateway) ValidateUserId(userID uint) (bool, error) {
+func (g *UserGateway) ValidateUserId(userID uint) (exists bool, isAdmin bool, err error) {
 	url := fmt.Sprintf("%s/users/%d", g.BaseURL, userID)
 
 	resp, err := g.HTTPClient.Get(url)
 	if err != nil {
-		return false, fmt.Errorf("Gateway error: %w", err)
+		return false, false, fmt.Errorf("gateway error: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return false, fmt.Errorf("User service returned status: %d", resp.StatusCode)
+		return false, false, fmt.Errorf("user service returned status: %d", resp.StatusCode)
 	}
 
 	var userResponse models.UserResponse
 	if err := json.NewDecoder(resp.Body).Decode(&userResponse); err != nil {
-		return false, fmt.Errorf("Error interpreting response: %w", err)
+		return false, false, fmt.Errorf("error interpreting response: %w", err)
 	}
-	return true, nil
+
+	switch userResponse.Role {
+	case "user":
+		return true, true, nil
+	case "admin":
+		return true, true, nil
+	default:
+		return false, false, fmt.Errorf("denied")
+	}
 }

--- a/backend/project_service/internal/handlers/project.go
+++ b/backend/project_service/internal/handlers/project.go
@@ -48,7 +48,8 @@ func CreateProjectHandler(service *service.ProjectService) http.HandlerFunc {
 				utils.RespondWithErrorMessage(w, http.StatusNotFound, "User not found")
 				return
 			}
-			utils.RespondWithErrorMessage(w, http.StatusInternalServerError, "Failed to create project")
+			if err.Error() == "no permissions"{
+			utils.RespondWithErrorMessage(w, http.StatusUnauthorized, "User is not allowed to create a project. Please login with different credentials")}
 			return
 		}
 

--- a/backend/user_service/internal/services/service.go
+++ b/backend/user_service/internal/services/service.go
@@ -44,7 +44,7 @@ func (s *UserService) RegisterUser(email, password string) (uint, error) {
 		Email:    email,
 		Password: string(hashedPassword),
 	}
-
+	user.Role = "user"
 	userID, err := s.repo.Create(&user)
 	if err != nil {
 		log.Println("Error saving user to DB:", err)


### PR DESCRIPTION
## Description
This PR implements role validation for the creation of projects. Only users with either the `admin` or `user` role attached to their user entity are allowed to create projects on the project API. Any other roles will receive a 401 response

## Type of Change
- [ ] Bugfix
- [x] New feature
- [ ] Documentation update

## Screenshot of Changes
Created a project with a user role:
![image](https://github.com/user-attachments/assets/45eb7cfa-a362-40cc-814e-79fed6ad8dfb)

Updated the user's role to be `viewer`:
![image](https://github.com/user-attachments/assets/6b8101af-a2d2-4027-9c60-f4582f100ddb)

Tried to create a project as a viewer:
![image](https://github.com/user-attachments/assets/9d663017-7ae7-4f61-9b08-e83338f26f0f)


Created a project with an admin role:
![image](https://github.com/user-attachments/assets/c8ac82b3-5f2f-428e-a35b-98ea872482e6)
![image](https://github.com/user-attachments/assets/48261549-7587-4155-b993-9f674976c396)


## Checklist:
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [x] I have updated the documentation (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass.

## Related Issues:
[Notion ticket](<paste link here)
